### PR TITLE
fix: ensure single control panel and sync loop state

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ The control panel in its minimized state.
 The full panel with all options visible.  
 ![Control Panel Expanded](https://raw.githubusercontent.com/Hank8933/YouTube-Speed-and-Loop/main/images/control-panel-expanded.jpg)
 
-## Changelog
+## 📦 Changelog
 
-- **v1.0** (Current): Initial release with playback speed and loop functionality.
+- **v1.0**
+
+    - Initial release with playback speed and loop functionality.
+
+- **v1.0.1** (Current)
+
+    - 🛠️ Fix: Prevent multiple control panels from appearing.
+
+    - 🔄 Fix: Keep custom loop toggle in sync with the native video loop state.
 
 ## License
 

--- a/script.user.js
+++ b/script.user.js
@@ -143,6 +143,12 @@
         return el;
     }
 
+    // Clean up existing panels
+    function cleanUpPanels() {
+        const existingPanels = document.querySelectorAll('.yt-custom-control-panel');
+        existingPanels.forEach(panel => panel.remove());
+    }
+
     // Create control panel DOM structure
     function createControlPanel() {
         const panel = createElement('div', 'yt-custom-control-panel');
@@ -328,6 +334,7 @@
     // Main initialization
     async function init() {
         const video = await waitForVideo();
+        cleanUpPanels(); // Clean up any existing panels before creating a new one
         const panel = createControlPanel();
 
         setTimeout(() => {
@@ -363,8 +370,7 @@
     const observer = new MutationObserver(() => {
         if (lastUrl !== location.href) {
             lastUrl = location.href;
-            const oldPanel = document.querySelector('.yt-custom-control-panel');
-            if (oldPanel) oldPanel.remove();
+            cleanUpPanels(); // Clean up any existing panels before reinitializing
             setTimeout(init, 1000);
         }
     });

--- a/script.user.js
+++ b/script.user.js
@@ -2,7 +2,7 @@
 // @name               YouTube Speed and Loop
 // @name:zh-TW         YouTube 播放速度與循環
 // @namespace          https://github.com/Hank8933
-// @version            1.0
+// @version            1.0.1
 // @description        Enhances YouTube with playback speeds beyond 2x and repeat functionality
 // @description:zh-TW  為 YouTube 提供超過 2 倍的播放速度控制和重複播放功能
 // @author             Hank8933


### PR DESCRIPTION
This pull request includes two related fixes aimed at improving the playback control experience:

1. Ensure single control panel instance

    - Removes any pre-existing control panels before rendering a new one.
  
    - Prevents multiple control panels from being displayed simultaneously.

2. Sync native loop state with custom panel

    - Ensures that changes to the native <video> loop state are accurately reflected in the custom control panel.
  
    - Improves consistency between native behavior and custom UI feedback.

These changes enhance both the user experience and the internal logic of the control panel rendering.